### PR TITLE
Only Use ID for Rental Equality Checks

### DIFF
--- a/src/edu/cscc/mvc/domain/Rental.java
+++ b/src/edu/cscc/mvc/domain/Rental.java
@@ -84,16 +84,12 @@ public class Rental {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Rental rental = (Rental) o;
-        return Objects.equals(name, rental.name) &&
-                format == rental.format &&
-                genre == rental.genre &&
-                Objects.equals(director, rental.director) &&
-                Objects.equals(year, rental.year);
+        return Objects.equals(id, rental.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, format, genre, director, year);
+        return Objects.hash(id);
     }
 
     @Override

--- a/test/edu/cscc/mvc/domain/RentalRepositoryImplTest.java
+++ b/test/edu/cscc/mvc/domain/RentalRepositoryImplTest.java
@@ -65,6 +65,20 @@ class RentalRepositoryImplTest {
         assertTrue(repository.readAll().isEmpty());
     }
 
+    @Test
+    public void itCanDeleteARentalAfterBeingUpdated() {
+        Rental rental = repository.create(createDefaultRental());
+        rental.setName("Alien");
+        rental.setFormat(Format.VHS);
+        rental.setDirector("Ridley Scott");
+        rental.setYear("1976");
+        Rental updated = repository.update(rental);
+
+        repository.delete(updated.getId());
+
+        assertTrue(repository.readAll().isEmpty());
+    }
+
     private Rental createDefaultRental() {
         Rental rental = new Rental("Rocky Horror Picture Show", Format.DVD, Genre.COMEDY, "Jim Sharman", "1975");
         return rental;


### PR DESCRIPTION
## Context
Currently the Rental [hashCode() and equals()](https://github.com/ColumbusStateWorkforceInnovation/java-3-model-view-controller-lab/blob/master/src/edu/cscc/mvc/domain/Rental.java#L83) methods are based on all properties except for the ID of object. This behavior causes a defect in situations where a rental is updated followed by an attempted delete in the [RentalRepositoryImpl](https://github.com/ColumbusStateWorkforceInnovation/java-3-model-view-controller-lab/blob/master/src/edu/cscc/mvc/domain/RentalRepositoryImpl.java), which is backed by a `HashSet<Rental>` collection. Because HashSet uses the calculated hashCode to determine equality it can't remove an updated Rental object based on its new properties, causing the `RentalRepositoryImpl.delete(UUID id)` operation to fail silently.

This PR correctly the above defect by updating the Rental `.equals()` and `.hashCode()` methods to only consider the ID of the Rental object.

## Changes
- [X] Updated the Rental `.equals()` and `.hashCode()` methods to only use the id property for their implementations.

## Validation
1. Check out the `master` branch.
2. Apply the "itCanDeleteARentalAfterBeingUpdated" test  to `test/edu/cscc/mvc/domain/RentalRepositoryImplTest.java`.
3. Run the test and watch it fail.
4. Check out this feature branch.
5. Run the tests and watch them all pass, including the "itCanDeleteARentalAfterBeingUpdated" test.